### PR TITLE
Refactor, so that always the queries are constructed identically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "azdevops-vscode-simplify" extension will be documented in this file.
 
+## [0.0.4]
+
+- respect settings `hideWorkItemsWithState` and `showWorkItemTypes` in quick pick view #13
+
 ## [0.0.3]
 
 - Stabilize login to help with the followup in #3 and the main issue in #4

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getAllWorkItemsAsQuickpicks, WorkItem } from './api/azdevops-api';
+import { getAllWorkItemsAsQuickpicks, WorkItemTreeItem } from './api/azdevops-api';
 import { getAzureDevOpsConnection, getGitExtension } from './helpers';
 import { AzDevOpsProvider } from './tree/azdevops-tree';
 
@@ -14,16 +14,16 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.window.registerTreeDataProvider('workitems', azDevOpsProvider);
 
 	context.subscriptions.push(vscode.commands.registerCommand('azdevops-vscode-simplify.refreshEntries', () => azDevOpsProvider.refresh()));
-	context.subscriptions.push(vscode.commands.registerCommand('azdevops-vscode-simplify.openWorkItem', (wi: WorkItem) => {
+	context.subscriptions.push(vscode.commands.registerCommand('azdevops-vscode-simplify.openWorkItem', (wi: WorkItemTreeItem) => {
 		vscode.env.openExternal(vscode.Uri.parse(wi.url));
 	}));
-	context.subscriptions.push(vscode.commands.registerCommand('azdevops-vscode-simplify.addToCommitMessage', async (wi: WorkItem) => {
+	context.subscriptions.push(vscode.commands.registerCommand('azdevops-vscode-simplify.addToCommitMessage', async (wi: WorkItemTreeItem) => {
 		getGitExtension().appendToCheckinMessage(`#${wi.wiId}`);
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand('azdevops-vscode-simplify.selectWorkItem', async () => {
 		await selectWorkItem();
 	}));
-	context.subscriptions.push(vscode.commands.registerCommand('azdevops-vscode-simplify.createBranch', (wi: WorkItem) => {
+	context.subscriptions.push(vscode.commands.registerCommand('azdevops-vscode-simplify.createBranch', (wi: WorkItemTreeItem) => {
 		wi.createBranch();
 	}));
 }

--- a/src/tree/azdevops-tree.ts
+++ b/src/tree/azdevops-tree.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
-import { getOrganizations, getProjects, getQueries, getWorkItems, Organization, Project, Query } from '../api/azdevops-api';
+import { getOrganizations, getProjects, getQueries, getWorkItemTreeItems, OrganizationTreeItem, ProjectTreeItem, QueryTreeItem } from '../api/azdevops-api';
 
 export class AzDevOpsProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
 
-    private _onDidChangeTreeData: vscode.EventEmitter<Organization | undefined | void> = new vscode.EventEmitter<Organization | undefined | void>();
-    readonly onDidChangeTreeData: vscode.Event<Organization | undefined | void> = this._onDidChangeTreeData.event;
+    private _onDidChangeTreeData: vscode.EventEmitter<OrganizationTreeItem | undefined | void> = new vscode.EventEmitter<OrganizationTreeItem | undefined | void>();
+    readonly onDidChangeTreeData: vscode.Event<OrganizationTreeItem | undefined | void> = this._onDidChangeTreeData.event;
 
     constructor() {
     }
@@ -20,12 +20,12 @@ export class AzDevOpsProvider implements vscode.TreeDataProvider<vscode.TreeItem
     async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
         if (!element) {
             return await getOrganizations();
-        } else if (element instanceof Organization) {
+        } else if (element instanceof OrganizationTreeItem) {
             return await getProjects(element);
-        } else if (element instanceof Project) {
+        } else if (element instanceof ProjectTreeItem) {
             return await getQueries(element);
-        } else if (element instanceof Query) {
-            return await getWorkItems(element);
+        } else if (element instanceof QueryTreeItem) {
+            return await getWorkItemTreeItems(element);
         }
         return [];
     }


### PR DESCRIPTION
Hi Tobias,

while working on #13 I noticed that we as well are not respecting the "hideWorkItemsWithState" setting.
I did not want to simply fix it, but refactored it instead in a way that the queries are created the same way, so that future changes can be implemented easier and more consistent which is why the PR is a bit bigger. If you have questions or don't like some changes, feel free to reach out to me.