### PR TITLE
feat(account): show current tenant and allow change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "azdevops-vscode-simplify" extension will be documented in this file.
 
+## [0.0.4]
+
+- Show the currently used tenant and allow to easily switch it as requested in #6
+
 ## [0.0.3]
 
 - Stabilize login to help with the followup in #3 and the main issue in #4

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,8 @@ import { getAllWorkItemsAsQuickpicks, WorkItem } from './api/azdevops-api';
 import { getAzureDevOpsConnection, getGitExtension } from './helpers';
 import { AzDevOpsProvider } from './tree/azdevops-tree';
 
+let tenantStatusBarItem: vscode.StatusBarItem;
+
 export async function activate(context: vscode.ExtensionContext) {
 
 	const azureAccountExtensionApi = getAzureDevOpsConnection().getAzureAccountExtensionApi();
@@ -26,26 +28,56 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('azdevops-vscode-simplify.createBranch', (wi: WorkItem) => {
 		wi.createBranch();
 	}));
+	tenantStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+	tenantStatusBarItem.command = 'azure-account.selectTenant';
+	context.subscriptions.push(tenantStatusBarItem);
+	context.subscriptions.push(getAzureDevOpsConnection().getAzureAccountExtensionApi().onSessionsChanged(updateTenantStatusBarItem));
+	context.subscriptions.push(getAzureDevOpsConnection().getAzureAccountExtensionApi().onStatusChanged(updateTenantStatusBarItem));
+	context.subscriptions.push(getAzureDevOpsConnection().getAzureAccountExtensionApi().onSubscriptionsChanged(updateTenantStatusBarItem));
+	context.subscriptions.push(getAzureDevOpsConnection().getAzureAccountExtensionApi().onFiltersChanged(updateTenantStatusBarItem));
 }
 
 export function deactivate() { }
 
+async function updateTenantStatusBarItem() {
+	let api = getAzureDevOpsConnection().getAzureAccountExtensionApi();
+	let sessions = api.sessions;
+	const tenants: TenantIdDescription[] = await ((api as any).loginHelper.tenantsTask);
+	if (sessions !== undefined && sessions.length > 0 && tenants !== undefined) {
+		let matchingTenant = tenants.find(t => t.tenantId === sessions[0].tenantId);
+		if (matchingTenant) {
+		 	tenantStatusBarItem.text = `Azure tenant: ${matchingTenant?.displayName}`;
+			tenantStatusBarItem.show();
+		} else {
+			tenantStatusBarItem.text = `Azure tenant: ${sessions[0].tenantId}`;
+			tenantStatusBarItem.show();
+		}
+	} else {
+		tenantStatusBarItem.hide();
+	}
+}
+
 async function selectWorkItem() {
 	try {
-		const workItems = await getAllWorkItemsAsQuickpicks();
-		if (workItems && workItems.length > 0) {
-			const workItem = await vscode.window.showQuickPick(workItems, {
-				title: 'Search for the title or ID of the work item you want to add to the commit message',
-				ignoreFocusOut: true,
-				matchOnDescription: true
-			});
-			if (workItem) {
-				getGitExtension().appendToCheckinMessage(`#${workItem.description!}`);
-			}
+	const workItems = await getAllWorkItemsAsQuickpicks();
+	if (workItems && workItems.length > 0) {
+		const workItem = await vscode.window.showQuickPick(workItems, {
+			title: 'Search for the title or ID of the work item you want to add to the commit message',
+			ignoreFocusOut: true,
+			matchOnDescription: true
+		});
+		if (workItem) {
+			getGitExtension().appendToCheckinMessage(`#${workItem.description!}`);
 		}
+	}
 	} catch (error) {
 		vscode.window.showErrorMessage(`An unexpected error occurred while retrieving work items: ${error}`);
 		console.error(error);
 		return [];
 	}
+}
+
+export interface TenantIdDescription {
+	tenantId: string;
+	displayName: string;
 }


### PR DESCRIPTION
Show the current tenant and allow to change it with a click, which calls the tenant selector of the Azure Account extension. This should help to show users if they are in a situation like described in #6 