### PR TITLE
feat(create branch): respect git prefix and optionally add wi id when creating branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "azdevops-vscode-simplify" extension will be documented in this file.
 
+## [0.0.4]
+
+- Respect the `Git: Branch prefix` setting if defined, as proposed in #7
+- Introduce a configuration setting `azdevops-vscode-simplify.useWorkitemIdInBranchName` to trigger the inclusion of the work item id in the proposed branch name, as proposed in #8
+
 ## [0.0.3]
 
 - Stabilize login to help with the followup in #3 and the main issue in #4

--- a/package.json
+++ b/package.json
@@ -164,6 +164,11 @@
             "type": "number",
             "default": 25,
             "description": "Maximum number of work items to show per query"
+          },
+          "azdevops-vscode-simplify.useWorkitemIdInBranchName": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use the work item id in the branch name proposal when you create a new branch"
           }
         }
       }

--- a/src/api/azdevops-api.ts
+++ b/src/api/azdevops-api.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { AzDevOpsConnection } from '../connection';
-import { getAzureDevOpsConnection, getGitExtension, hideWorkItemsWithState, maxNumberOfWorkItems, showWorkItemTypes, sortOrderOfWorkItemState } from '../helpers';
+import { getAzureDevOpsConnection, getGitExtension, hideWorkItemsWithState, maxNumberOfWorkItems, showWorkItemTypes, sortOrderOfWorkItemState, useWorkitemIdInBranchName } from '../helpers';
 
 export async function getOrganizations(): Promise<Organization[]> {
     try {
@@ -400,8 +400,10 @@ export class WorkItem extends vscode.TreeItem {
     public async createBranch() {
         const repo = getGitExtension().getRepo();
         if (repo) {
+            const gitPrefix = vscode.workspace.getConfiguration('git').get('branchPrefix', "");
             let newBranch = await vscode.window.showInputBox({
-                prompt: "Please enter the name of the new branch"
+                prompt: "Please enter the name of the new branch",
+                value: `${gitPrefix !== "" ? `${gitPrefix}` : ""}${useWorkitemIdInBranchName() ? this.wiId : ""}`
             });
             if (newBranch) {
                 if (repo.state.HEAD?.upstream && repo.state.remotes.length > 0 && repo.state.remotes[0].fetchUrl) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,6 +17,10 @@ export function showWorkItemTypes(): string[] {
     return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('showWorkItemTypes', [])
 }
 
+export function useWorkitemIdInBranchName(): boolean {
+    return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('useWorkitemIdInBranchName', false)
+}
+
 export function hideWorkItemsWithState(): string[] {
     let def: string[] | undefined = vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('hideWorkItemsWithState');
     if (def === undefined) { def = []; }


### PR DESCRIPTION
- Respect the `Git: Branch prefix` setting if defined, as proposed in #7
- Introduce a configuration setting `azdevops-vscode-simplify.useWorkitemIdInBranchName` to trigger the inclusion of the work item id in the proposed branch name, as proposed in #8
