### PR TITLE
Add the possibility to show the parents of the Work Items as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "azdevops-vscode-simplify" extension will be documented in this file.
 
+## [0.0.7]
+
+- Add the possibility to show the parents of the Work Items as well using the setting `azdevops-vscode-simplify.showParentsOfWorkItems`. #11
+- Add the possibility to select multiple Work Items when adding them to the commit message and using the command for that.
+
 ## [0.0.6]
 
 - Fix problem where creating a branch didn't work for https-based remotes #24

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azdevops-vscode-simplify",
   "displayName": "Azure DevOps Simplify",
   "description": "An Extension to make working with Azure DevOps in VS Code more efficient",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "publisher": "tfenster",
   "author": {
     "name": "David Feldhoff",
@@ -169,6 +169,11 @@
             "type": "boolean",
             "default": false,
             "description": "Use the work item id in the branch name proposal when you create a new branch"
+          },
+          "azdevops-vscode-simplify.showParentsOfWorkItems": {
+            "type": "boolean",
+            "default": false,
+            "description": "Show parents of the work items as well. The parent will then be loaded, regardless of the work item type. That means that the setting showWorkItemTypes is not considered when loading the parents."
           }
         }
       }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -14,11 +14,11 @@ export function getGitExtension(): GitExtension {
 }
 
 export function showWorkItemTypes(): string[] {
-    return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('showWorkItemTypes', [])
+    return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('showWorkItemTypes', []);
 }
 
 export function useWorkitemIdInBranchName(): boolean {
-    return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('useWorkitemIdInBranchName', false)
+    return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('useWorkitemIdInBranchName', false);
 }
 
 export function hideWorkItemsWithState(): string[] {


### PR DESCRIPTION
using the setting `azdevops-vscode-simplify.showParentsOfWorkItems`. #11

- Add the possibility to select multiple Work Items when adding them to the commit message and using the command for that.

https://user-images.githubusercontent.com/53570297/205514181-b8a6fce9-4594-4e4d-9bce-7f47c32833ee.mp4

