### PR TITLE
do not cache memberId as it might be that it belongs to an account that is not logged in anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the "azdevops-vscode-simplify" extension will be document
 - Add the possibility to show the parents of the Work Items as well using the setting `azdevops-vscode-simplify.showParentsOfWorkItems`. #11
 - Add the possibility to select multiple Work Items when adding them to the commit message and using the command for that.
 - Add setting `azdevops-vscode-simplify.organizationAndProjectFilter` to filter organizations and projects. #10
+- Improve switching Azure accounts to try to fix #4
 
 ## [0.0.6]
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -25,18 +25,16 @@ export class AzDevOpsConnection {
     }
 
     public async getMemberId(): Promise<string | undefined> {
-        if (AzDevOpsConnection.memberId === undefined) {
-            try {
-                // https://learn.microsoft.com/en-us/rest/api/azure/devops/profile/profiles/get?view=azure-devops-rest-7.1&tabs=HTTP
-                const memberIdData = await this.get('https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=6.0');
-                if (!memberIdData) {
-                    return undefined;
-                }
-                AzDevOpsConnection.memberId = memberIdData.id;
-            } catch (error) {
-                console.error(error);
-                vscode.window.showErrorMessage(`Unexpected error when trying to retrieve your member id: ${error}`);
+        try {
+            // https://learn.microsoft.com/en-us/rest/api/azure/devops/profile/profiles/get?view=azure-devops-rest-7.1&tabs=HTTP
+            const memberIdData = await this.get('https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=6.0');
+            if (!memberIdData) {
+                return undefined;
             }
+            AzDevOpsConnection.memberId = memberIdData.id;
+        } catch (error) {
+            console.error(error);
+            vscode.window.showErrorMessage(`Unexpected error when trying to retrieve your member id: ${error}`);
         }
         return AzDevOpsConnection.memberId;
     }


### PR DESCRIPTION
I made some tests together with Luc for #4, but unfortunately my results are not the best yet.

The only thing I could find out right now is the following:
- Luc was signed in with Account x. With that account there've been issues to load the organizations, so that we showed the message `The Azure login failed. Please try to run 'Azure: Sign Out' and 'Azure: Sign In' manually.` 
He did that and logged in to an account, but then the memberId was still the one from the old logged in account and so the http request to load the accounts was sent with an old memberId that does not fit to the token we add in the http-requests.
After a reload window (=clear the cache of memberId) he was able to load the organizations successfully.

I removed the caching for Luc in a vsix I've sent him. And it helped him a bit, which is why I'd like to remove the caching for everyone as I think the benefit of that caching isn't that much. Would you agree with that?

Nevertheless I fear that there is more that's going wrong in #4, but I've no clue yet what that is.