### PR TITLE
chore(refactor): extract Azure Account extension API from Azure DevOps connection

### DIFF
--- a/src/api/azure-account-api.ts
+++ b/src/api/azure-account-api.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+import { AzureExtensionApiProvider } from "@microsoft/vscode-azext-utils/api";
+import { AzureAccountExtensionApi } from "../types/azure-account.api";
+
+export class AzureAccountExtension {
+    private static azureAccountExtensionApi: AzureAccountExtensionApi;
+
+    constructor() {
+        if (AzureAccountExtension.azureAccountExtensionApi === undefined) {
+            const azureAccountExtension = vscode.extensions.getExtension<AzureExtensionApiProvider>("ms-vscode.azure-account");
+            if (azureAccountExtension) {
+                AzureAccountExtension.azureAccountExtensionApi = azureAccountExtension.exports.getApi('1.0.0');
+            } else {
+                vscode.window.showErrorMessage("Azure Account extension not found. This extension is required for the full functionality of Azure DevOps Simplify.");
+            }
+        }
+    }
+
+    public getAzureAccountExtensionApi(): AzureAccountExtensionApi {
+        return AzureAccountExtension.azureAccountExtensionApi;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,13 @@
 import * as vscode from 'vscode';
 import { getAllWorkItemsAsQuickpicks, WorkItemQuickPickItems, WorkItemTreeItem } from './api/azdevops-api';
-import { getAzureDevOpsConnection, getGitExtension } from './helpers';
+import { getAzureAccountExtension, getGitExtension } from './helpers';
 import { AzDevOpsProvider } from './tree/azdevops-tree';
 
 let tenantStatusBarItem: vscode.StatusBarItem;
 
 export async function activate(context: vscode.ExtensionContext) {
 
-	const azureAccountExtensionApi = getAzureDevOpsConnection().getAzureAccountExtensionApi();
+	const azureAccountExtensionApi = getAzureAccountExtension().getAzureAccountExtensionApi();
 	if (!(await azureAccountExtensionApi.waitForLogin())) {
 		await vscode.commands.executeCommand('azure-account.askForLogin');
 	}
@@ -31,16 +31,16 @@ export async function activate(context: vscode.ExtensionContext) {
 	tenantStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 	tenantStatusBarItem.command = 'azure-account.selectTenant';
 	context.subscriptions.push(tenantStatusBarItem);
-	context.subscriptions.push(getAzureDevOpsConnection().getAzureAccountExtensionApi().onSessionsChanged(updateTenantStatusBarItem));
-	context.subscriptions.push(getAzureDevOpsConnection().getAzureAccountExtensionApi().onStatusChanged(updateTenantStatusBarItem));
-	context.subscriptions.push(getAzureDevOpsConnection().getAzureAccountExtensionApi().onSubscriptionsChanged(updateTenantStatusBarItem));
-	context.subscriptions.push(getAzureDevOpsConnection().getAzureAccountExtensionApi().onFiltersChanged(updateTenantStatusBarItem));
+	context.subscriptions.push(getAzureAccountExtension().getAzureAccountExtensionApi().onSessionsChanged(updateTenantStatusBarItem));
+	context.subscriptions.push(getAzureAccountExtension().getAzureAccountExtensionApi().onStatusChanged(updateTenantStatusBarItem));
+	context.subscriptions.push(getAzureAccountExtension().getAzureAccountExtensionApi().onSubscriptionsChanged(updateTenantStatusBarItem));
+	context.subscriptions.push(getAzureAccountExtension().getAzureAccountExtensionApi().onFiltersChanged(updateTenantStatusBarItem));
 }
 
 export function deactivate() { }
 
 async function updateTenantStatusBarItem() {
-	let api = getAzureDevOpsConnection().getAzureAccountExtensionApi();
+	let api = getAzureAccountExtension().getAzureAccountExtensionApi();
 	let sessions = api.sessions;
 	const tenants: TenantIdDescription[] = await ((api as any).loginHelper.tenantsTask);
 	if (sessions && sessions.length > 0) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,9 +1,11 @@
 import * as vscode from 'vscode';
+import { AzureAccountExtension } from './api/azure-account-api';
 import { GitExtension } from './api/git-api';
 import { AzDevOpsConnection } from './connection';
 
 let azDevOpsConnection = new AzDevOpsConnection();
 let gitExtension = new GitExtension();
+let azureAccountExtension = new AzureAccountExtension();
 
 export function getAzureDevOpsConnection(): AzDevOpsConnection {
     return azDevOpsConnection;
@@ -11,6 +13,10 @@ export function getAzureDevOpsConnection(): AzDevOpsConnection {
 
 export function getGitExtension(): GitExtension {
     return gitExtension;
+}
+
+export function getAzureAccountExtension(): AzureAccountExtension {
+    return azureAccountExtension;
 }
 
 export function showWorkItemTypes(): string[] {


### PR DESCRIPTION
@DavidFeldhoff when bringing our current features into COSMO Alpaca, I saw that we had mixed two things that actually shouldn't be mixed: The Azure DevOps connection and the Azure Account extension API. I tried to untangle these and model the Azure Account extension API access in a similar way to how we access the Git extension API. Do you agree with this?