### PR TITLE
Choose a repo if you've multiple opened before executing an action. #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "azdevops-vscode-simplify" extension will be documented in this file.
 
+## [0.0.8]
+
+- Choose a repo if you've multiple opened before executing an action. #37
+
 ## [0.0.7]
 
 - Ask for branch to base on when creating a new branch #28

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The extension gives you a new view which shows all your Azure DevOps organizatio
 - Recent activity in project: All work items that have recently been changed in the project
 - Recently mentioned: All work items where you have recently been mentioned
 
-For all work items, you can add it to the commit message, create a new branch linked to it and open it in the browser.
+For all work items, you can add it to the commit message, create a new branch linked to it and open it in the browser. Note: If you're working with multiple repositories at the same time, then you're asked on which repository you want to execute the aforementioned actions.
 
 Please check the settings below for more details on how you can change the behavior of this extension like which work item types or how many of them are shown, which branch name is suggested when creating a new branch and further things.
 
@@ -24,7 +24,7 @@ This extension contributes the following settings:
 * `azdevops-vscode-simplify.hideWorkItemsWithState`: Use this setting to define which work items should be hidden. By default closed and removed ones are not shown.
 * `azdevops-vscode-simplify.sortOrderOfWorkItemState`: Work items are sorted by state, then by name. With this setting you're able to change the order of the states or add your own custom ones.
 * `azdevops-vscode-simplify.maxNumberOfWorkItems`: Use this setting to define the maximum number of work items that are shown below a query (default: 25).
-* `azdevops-vscode-simplify.createBranch.useWorkitemIdInBranchName`: Use the work item id in the branch name proposal when you create a new branch
+* `azdevops-vscode-simplify.createBranch.branchNameProposal`: Use the work item id and/or description as branch name proposal when you create a new branch
 * `azdevops-vscode-simplify.createBranch.createBranchBasedOn`: Define the base branch when creating a new branch
 * `azdevops-vscode-simplify.createBranch.askForBaseBranch`: If this is selected, the `createBranchBasedOn` setting is just a proposal and you can select another branch as base.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azdevops-vscode-simplify",
   "displayName": "Azure DevOps Simplify",
   "description": "An Extension to make working with Azure DevOps in VS Code more efficient",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "tfenster",
   "author": {
     "name": "David Feldhoff",

--- a/src/api/azdevops-api.ts
+++ b/src/api/azdevops-api.ts
@@ -4,6 +4,7 @@ import { askForBaseBranch, createBranchBasedOn, getAzureDevOpsConnection, getGit
 import { RefType } from '../types/git';
 import { Repository } from '../types/git';
 import escapeStringRegexp from 'escape-string-regexp';
+import { RepoSelection } from './git-api';
 
 interface IWorkItemType { name: string; devOpsIcon: string; referenceName?: string };
 interface IWorkItem { id: string; fields: { [key: string]: string | any; }; themeIcon: vscode.ThemeIcon; }
@@ -12,7 +13,7 @@ const preloadedOrganizationWithProjects: Map<OrganizationTreeItem, ProjectTreeIt
 
 export async function getOrganizations(): Promise<OrganizationTreeItem[]> {
     try {
-        const repo = await getGitExtension().getRepo(false);
+        const repo = await getGitExtension().getRepoSilent();
         let repoAnalysis: RepoAnalysis | undefined;
         if (repo) {
             repoAnalysis = analyzeGitRepo(repo);
@@ -69,7 +70,7 @@ export async function getProjects(organization: OrganizationTreeItem): Promise<P
     if (preloadedOrganizationWithProjects.has(organization)) {
         return preloadedOrganizationWithProjects.get(organization)!;
     }
-    const repo = await getGitExtension().getRepo(false);
+    const repo = await getGitExtension().getRepoSilent();
     let repoAnalysis: RepoAnalysis | undefined;
     if (repo) {
         repoAnalysis = analyzeGitRepo(repo);
@@ -111,52 +112,49 @@ export async function getProjects(organization: OrganizationTreeItem): Promise<P
     }
 }
 export interface WorkItemQuickPickItems { label: string; kind?: vscode.QuickPickItemKind; description?: string; detail?: string; picked?: boolean; alwaysShow?: boolean; buttons?: readonly vscode.QuickInputButton[]; workItemId: number; parentId?: number; }
-export async function getAllWorkItemsAsQuickpicks(): Promise<WorkItemQuickPickItems[] | undefined> {
-    const repo = await getGitExtension().getRepo();
-    if (repo) {
-        const repoAnalysis = analyzeGitRepo(repo);
-        if (repoAnalysis) {
-            const query = await createQueryString("", repoAnalysis.projectUrl);
-            let workItems = await loadWorkItemObjects(query, repoAnalysis.orgUrl, repoAnalysis.projectUrl, false);
+export async function getAllWorkItemsAsQuickpicks(repo: Repository): Promise<WorkItemQuickPickItems[] | undefined> {
+    const repoAnalysis = analyzeGitRepo(repo);
+    if (repoAnalysis) {
+        const query = await createQueryString("", repoAnalysis.projectUrl);
+        let workItems = await loadWorkItemObjects(query, repoAnalysis.orgUrl, repoAnalysis.projectUrl, false);
 
-            const showParentsOfWorkItems = vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('showParentsOfWorkItems', false);
-            let parentChildRelationMap: { "parent": number, "child": number }[] = [];
-            if (showParentsOfWorkItems) {
-                parentChildRelationMap = await getParentChildRelationMap(repoAnalysis.projectUrl, workItems.map(wi => +wi.id));
-                const parentWorkItemIdsNotYetLoaded = parentChildRelationMap.filter(mapEntry => !workItems.some(loadedWorkItem => parseInt(loadedWorkItem.id) === mapEntry.parent)).map(entry => entry.parent);
-                if (parentWorkItemIdsNotYetLoaded.length > 0) {
-                    const queryToLoadMissingParents = await createQueryString(`[System.Id] in (${parentWorkItemIdsNotYetLoaded.join(',')})`, repoAnalysis.projectUrl, false);
-                    const parentWorkItems = await loadWorkItemObjects(queryToLoadMissingParents, repoAnalysis.orgUrl, repoAnalysis.projectUrl, false);
-                    workItems = workItems.concat(parentWorkItems);
-                }
+        const showParentsOfWorkItems = vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('showParentsOfWorkItems', false);
+        let parentChildRelationMap: { "parent": number, "child": number }[] = [];
+        if (showParentsOfWorkItems) {
+            parentChildRelationMap = await getParentChildRelationMap(repoAnalysis.projectUrl, workItems.map(wi => +wi.id));
+            const parentWorkItemIdsNotYetLoaded = parentChildRelationMap.filter(mapEntry => !workItems.some(loadedWorkItem => parseInt(loadedWorkItem.id) === mapEntry.parent)).map(entry => entry.parent);
+            if (parentWorkItemIdsNotYetLoaded.length > 0) {
+                const queryToLoadMissingParents = await createQueryString(`[System.Id] in (${parentWorkItemIdsNotYetLoaded.join(',')})`, repoAnalysis.projectUrl, false);
+                const parentWorkItems = await loadWorkItemObjects(queryToLoadMissingParents, repoAnalysis.orgUrl, repoAnalysis.projectUrl, false);
+                workItems = workItems.concat(parentWorkItems);
             }
-
-            const wiDetails: WorkItemQuickPickItems[] = workItems.map((wi: IWorkItem) => {
-                const assignedTo = `Assigned to: ${(wi.fields["System.AssignedTo"] ? wi.fields["System.AssignedTo"].displayName : "Unassigned")}`;
-                let detail = assignedTo;
-                let buttons: vscode.QuickInputButton[] = [];
-                const parent = parentChildRelationMap.find(entry => entry.child === +wi.id)?.parent;
-                const childs = parentChildRelationMap.filter(entry => entry.parent === +wi.id).map(entry => entry.child);
-                if (parent) {
-                    detail += `; Child of ${parent}`;
-                    buttons.push({
-                        iconPath: new vscode.ThemeIcon("references"),
-                        tooltip: "Add parent"
-                    });
-                }
-                if (childs.length > 0) { detail += `; Parent of ${childs.join(',')}`; }
-
-                return {
-                    label: `$(${wi.themeIcon.id}) ${wi.fields["System.Title"]}`,
-                    description: `${wi.id}`,
-                    detail: detail,
-                    buttons: buttons,
-                    workItemId: +wi.id,
-                    parentId: parent
-                };
-            });
-            return wiDetails;
         }
+
+        const wiDetails: WorkItemQuickPickItems[] = workItems.map((wi: IWorkItem) => {
+            const assignedTo = `Assigned to: ${(wi.fields["System.AssignedTo"] ? wi.fields["System.AssignedTo"].displayName : "Unassigned")}`;
+            let detail = assignedTo;
+            let buttons: vscode.QuickInputButton[] = [];
+            const parent = parentChildRelationMap.find(entry => entry.child === +wi.id)?.parent;
+            const childs = parentChildRelationMap.filter(entry => entry.parent === +wi.id).map(entry => entry.child);
+            if (parent) {
+                detail += `; Child of ${parent}`;
+                buttons.push({
+                    iconPath: new vscode.ThemeIcon("references"),
+                    tooltip: "Add parent"
+                });
+            }
+            if (childs.length > 0) { detail += `; Parent of ${childs.join(',')}`; }
+
+            return {
+                label: `$(${wi.themeIcon.id}) ${wi.fields["System.Title"]}`,
+                description: `${wi.id}`,
+                detail: detail,
+                buttons: buttons,
+                workItemId: +wi.id,
+                parentId: parent
+            };
+        });
+        return wiDetails;
     }
 
     async function getParentChildRelationMap(projectUrl: string, workItemIds: number[]) {
@@ -445,20 +443,22 @@ async function createQueryString(additionalFilter: string | undefined, projectUr
     return query;
 }
 
-function analyzeGitRepo(repo: Repository): RepoAnalysis | undefined {
+export function analyzeGitRepo(repo: Repository): RepoAnalysis | undefined {
     if (repo.state.remotes[0].fetchUrl) {
         let remoteRepoName = repo.state.remotes[0].fetchUrl;
         let pathSegments: string[] | undefined;
         let repoSegmentNo = 0;
-        if (remoteRepoName.startsWith("git@")) {  // e.g. git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
-            remoteRepoName = remoteRepoName.substring(remoteRepoName.indexOf("/") + 1);
-            pathSegments = remoteRepoName.split("/");
-            repoSegmentNo = 2;
-        }
-        else if (remoteRepoName.startsWith('https://')) {  // e.g. https://{org}@dev.azure.com/{org}/{project}/_git/{repo}
-            remoteRepoName = remoteRepoName.substring(remoteRepoName.indexOf("/", 10) + 1);
-            pathSegments = remoteRepoName.split("/");
-            repoSegmentNo = 3;
+        if (remoteRepoName.includes("dev.azure.com")) {
+            if (remoteRepoName.startsWith("git@")) {  // e.g. git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
+                remoteRepoName = remoteRepoName.substring(remoteRepoName.indexOf("/") + 1);
+                pathSegments = remoteRepoName.split("/");
+                repoSegmentNo = 2;
+            }
+            else if (remoteRepoName.startsWith('https://')) {  // e.g. https://{org}@dev.azure.com/{org}/{project}/_git/{repo}
+                remoteRepoName = remoteRepoName.substring(remoteRepoName.indexOf("/", 10) + 1);
+                pathSegments = remoteRepoName.split("/");
+                repoSegmentNo = 3;
+            }
         }
         if (pathSegments && pathSegments.length > 1) {
             const orgUrl = `https://dev.azure.com/${pathSegments[0]}`;
@@ -575,7 +575,7 @@ export class WorkItemTreeItem extends vscode.TreeItem {
     contextValue = 'workitem';
 
     public async createBranch() {
-        const repo = await getGitExtension().getRepo();
+        const repo = await getGitExtension().getRepoOrShowWarning(RepoSelection.choose);
         if (repo) {
             let repoAnalysis = analyzeGitRepo(repo);
             if (repoAnalysis) {
@@ -595,12 +595,9 @@ export class WorkItemTreeItem extends vscode.TreeItem {
                     }
                 });
                 if (newBranch) {
-                    if (repo.state.HEAD?.upstream && repo.state.remotes.length > 0 && repo.state.remotes[0].fetchUrl) {
-                        // get substring after last slash
-                        let remoteRepoName = repo.state.remotes[0].fetchUrl;
-                        remoteRepoName = remoteRepoName.substring(remoteRepoName.lastIndexOf("/") + 1);
+                    if (repo.state.HEAD?.upstream) {
                         try {
-                            let remoteRepo = await getAzureDevOpsConnection().get(`${this.parent.parent.url}/_apis/git/repositories/${remoteRepoName}?api-version=5.1-preview.1`);
+                            let remoteRepo = await getAzureDevOpsConnection().get(`${this.parent.parent.url}/_apis/git/repositories/${repoAnalysis.repoNameOrId}?api-version=5.1-preview.1`);
                             if (remoteRepo === undefined) {
                                 return;
                             }
@@ -633,6 +630,7 @@ export class WorkItemTreeItem extends vscode.TreeItem {
                             vscode.window.showInformationMessage(`Created branch ${newBranch} and linked it to work item ${this.wiId}`);
                         } catch (error) {
                             vscode.window.showErrorMessage(`Failed to create branch ${newBranch} and/or link it to work item ${this.wiId}`);
+                            console.log(error);
                         }
                     } else {
                         vscode.window.showErrorMessage("No upstream branch found. This functionality only works with an upstream branch.");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,7 +92,7 @@ async function selectWorkItem() {
 			});
 		} else {
 			quickPick.hide();
-			vscode.window.showWarningMessage('Uanble to load work items.');
+			vscode.window.showWarningMessage('Unable to load work items.');
 		}
 	} catch (error) {
 		vscode.window.showErrorMessage(`An unexpected error occurred while retrieving work items: ${error}`);


### PR DESCRIPTION
Hi @tfenster,
I created this PR after @fvet asked for it. I think this should do it. If there are multiple repos, then you're asked before which repo to use.
- Command `AzDevOps Simplify: Add work item to commit message`: You're asked before the work items are shown
  - They're shown before to make sure that the right work items are shown in case the different repos are also part of different projects.
- TreeView
  - Add work item id to commit message: after clicking the action
  - Create branch: after clicking the action.

When opening the treeview first time we're also checking the repo. But there I'm just getting the first one silently as it's just used to find the current organization and project to expand it initially and 1. I think it happens rarely that you've multiple repos of different projects and 2. even if case 1 happens, then you still don't care if another project is expanded initially.