### PR TITLE
Add new setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "azdevops-vscode-simplify" extension will be documented in this file.
 
+## [0.0.8]
+
+- Add new setting `azdevops-vscode-simplify.createBranch.branchNameProposal` which enables also adding the work item description and obsolete `useWorkitemIdInBranchName` setting for it. #36
+
 ## [0.0.7]
 
 - Ask for branch to base on when creating a new branch #28

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azdevops-vscode-simplify",
   "displayName": "Azure DevOps Simplify",
   "description": "An Extension to make working with Azure DevOps in VS Code more efficient",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "tfenster",
   "author": {
     "name": "David Feldhoff",
@@ -191,7 +191,19 @@
           "azdevops-vscode-simplify.createBranch.useWorkitemIdInBranchName": {
             "type": "boolean",
             "default": false,
-            "description": "Use the work item id in the branch name proposal when you create a new branch"
+            "description": "Use the work item id in the branch name proposal when you create a new branch",
+            "markdownDeprecationMessage": "Use this setting instead: `azdevops-vscode-simplify.createBranch.branchNameProposal`"
+          },
+          "azdevops-vscode-simplify.createBranch.branchNameProposal": {
+            "type": "string",
+            "default": "nothing",
+            "enum": [
+              "nothing",
+              "workitemId",
+              "workitemDescription",
+              "workitemIdAndDescription"
+            ],
+            "description": "Use the work item id and/or description in the branch name proposal when you create a new branch"
           },
           "azdevops-vscode-simplify.createBranch.createBranchBasedOn": {
             "type": "string",

--- a/src/api/azdevops-api.ts
+++ b/src/api/azdevops-api.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { AzDevOpsConnection } from '../connection';
-import { askForBaseBranch, createBranchBasedOn, getAzureDevOpsConnection, getGitExtension, hideWorkItemsWithState, maxNumberOfWorkItems, showWorkItemTypes, sortOrderOfWorkItemState, useWorkitemIdInBranchName } from '../helpers';
+import { askForBaseBranch, createBranchBasedOn, getAzureDevOpsConnection, getGitExtension, hideWorkItemsWithState, maxNumberOfWorkItems, showWorkItemTypes, sortOrderOfWorkItemState, getBranchNameProposalSetting, BranchNameProposal } from '../helpers';
 import { RefType } from '../types/git';
 import { Repository } from '../types/git';
 import escapeStringRegexp from 'escape-string-regexp';
@@ -582,10 +582,9 @@ export class WorkItemTreeItem extends vscode.TreeItem {
                 const remoteRefs: string[] = await getRemoteRefs(this.parent.parent.url, repoAnalysis.repoNameOrId);
                 const localRefs: string[] = repo.state.refs.filter(ref => ref.name !== undefined && ref.type !== RefType.RemoteHead).map(ref => ref.name!);
                 const existingRefs = remoteRefs.concat(localRefs);
-                const gitPrefix = vscode.workspace.getConfiguration('git').get('branchPrefix', "");
                 let newBranch = await vscode.window.showInputBox({
                     prompt: "Please enter the name of the new branch",
-                    value: `${gitPrefix !== "" ? `${gitPrefix}` : ""}${useWorkitemIdInBranchName() ? this.wiId : ""}`,
+                    value: this.getBranchNameProposal(),
                     validateInput: (value: string) => {
                         const existingref = existingRefs.find(refName => refName.toLowerCase() === value.toLowerCase());
                         if (existingref) {
@@ -691,5 +690,27 @@ export class WorkItemTreeItem extends vscode.TreeItem {
             }
             return remoteRefs;
         }
+    }
+
+    private getBranchNameProposal() {
+        const gitPrefix = vscode.workspace.getConfiguration('git').get('branchPrefix', "");
+        let branchNameProposal = gitPrefix !== "" ? `${gitPrefix}` : "";
+        let safeDescription = this.label.trim().toLowerCase().replace(/ /g, "-");
+        safeDescription = safeDescription.replace(/[^\w-]/g, "");
+        switch (getBranchNameProposalSetting()) {
+            case BranchNameProposal.workitemId:
+                branchNameProposal += this.wiId;
+                break;
+            case BranchNameProposal.workitemDescription:
+                branchNameProposal += safeDescription;
+                break;
+            case BranchNameProposal.workitemIdAndDescription:
+                branchNameProposal += `${this.wiId}-${safeDescription}`;
+                break;
+            default:
+                break;
+        }
+        const maxBranchNameLength = 370;
+        return branchNameProposal.substring(0, maxBranchNameLength);
     }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -23,14 +23,30 @@ export function showWorkItemTypes(): string[] {
     return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('showWorkItemTypes', []);
 }
 
-export function useWorkitemIdInBranchName(): boolean {
-    return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('useWorkitemIdInBranchName', false) ||
-        vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('createBranch.useWorkitemIdInBranchName', false);
+export function getBranchNameProposalSetting(): BranchNameProposal {
+    let branchNameProposal = BranchNameProposal.nothing;
+    const branchNameProposalAsString = vscode.workspace.getConfiguration('azdevops-vscode-simplify').get<string>('createBranch.branchNameProposal');
+    if (branchNameProposalAsString) {
+        branchNameProposal = BranchNameProposal[branchNameProposalAsString as any] as unknown as BranchNameProposal;
+    } else {
+        const useId: boolean = vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('useWorkitemIdInBranchName', false) ||
+            vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('createBranch.useWorkitemIdInBranchName', false);
+        if (useId) {
+            branchNameProposal = BranchNameProposal.workitemId;
+        }
+    }
+    return branchNameProposal;
 }
-export function createBranchBasedOn(): string{
+export enum BranchNameProposal {
+    "nothing",
+    "workitemId",
+    "workitemDescription",
+    "workitemIdAndDescription"
+}
+export function createBranchBasedOn(): string {
     return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('createBranch.createBranchBasedOn', "default branch of remote repo");
 }
-export function askForBaseBranch(): boolean{
+export function askForBaseBranch(): boolean {
     return vscode.workspace.getConfiguration('azdevops-vscode-simplify').get('createBranch.askForBaseBranch', false);
 }
 


### PR DESCRIPTION
Add new setting  `azdevops-vscode-simplify.createBranch.branchNameProposal` which enables also adding the work item description and obsolete `useWorkitemIdInBranchName` setting for it.
Remove any non-word-characters from the work item description, make it lowercase, replace spaces with dashes and cut at 370 characters as the limit is somewhere between 380-390 (read different values in different forums, but 370 should be save and enough)